### PR TITLE
Prevent iOS touch events for disabled buttons

### DIFF
--- a/index.js
+++ b/index.js
@@ -147,7 +147,7 @@ var vueTouchEvents = {
 
             // get the callback list
             var callbacks = $this.callbacks[eventType] || []
-            if (callbacks.length === 0) {
+            if (callbacks.length === 0 || $el.getAttribute('disabled')) {
                 return null
             }
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vue2-touch-events",
-  "version": "1.0.3",
+  "version": "1.0.4",
   "description": "Simple touch events support for vueJS2",
   "main": "index.js",
   "repository": {


### PR DESCRIPTION
in iOS Safari, see that a `v-touch=` handler is not triggered when the button also has `disabled="disabled"`

DO NOT MERGE INTO MASTER